### PR TITLE
Fixed issue when telling SP to connect to IAS Production instance but uses IAS Development Instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ The service provider's remote attestation server _does not require Intel SGX har
 * Download the source for the latest release of OpenSSL 1.1.0, then build and install it into a _non-system directory_ such as /opt (note that both `--prefix` and `--openssldir` should be set when building OpenSSL 1.1.0). For example:
 
   ```
-  $ wget https://www.openssl.org/source/openssl-1.1.0h.tar.gz
-  $ tar xf openssl-1.1.0h.tar.gz
-  $ cd openssl-1.1.0h
-  $ ./Configure --prefix=/opt/openssl/1.1.0h --openssldir=/opt/openssl/1.1.0h
+  $ wget https://www.openssl.org/source/openssl-1.1.0i.tar.gz
+  $ tar xf openssl-1.1.0i.tar.gz
+  $ cd openssl-1.1.0i
+  $ ./Configure --prefix=/opt/openssl/1.1.0i --openssldir=/opt/openssl/1.1.0i
   $ make
   $ sudo make install
   ```
@@ -84,7 +84,7 @@ First, prepare the build system (GNU* automake and autoconf) by running `bootstr
 
   ```
   $ ./bootstrap
-  $ ./configure --with-openssldir=/opt/openssl/1.1.0h
+  $ ./configure --with-openssldir=/opt/openssl/1.1.0i
   $ make
   ```
 

--- a/run.in
+++ b/run.in
@@ -117,6 +117,7 @@ then
 		-C "$IAS_CLIENT_CERT_FILE" \
 		$sp_cert_key $sp_noproxy $sp_proxy $sp_cert_passwd $sp_cert_type \
 		$flag_linkable $flag_debug $flag_verbose \
+                $sp_production \
 		"$@" 
 else
 	echo "$PROG: unrecognized instance (expected run-client or run-server)" >&2

--- a/sp.cpp
+++ b/sp.cpp
@@ -230,6 +230,11 @@ int main(int argc, char *argv[])
 		case 'G':
 			ias_list_agents(stdout);
 			return 1;
+
+                case 'P':
+                        flag_prod = 1;
+                        break;
+
 		case 'S':
 			if (!from_hexstring_file((unsigned char *)&config.spid, optarg, 16)) {
 				eprintf("SPID must be 32-byte hex string\n");


### PR DESCRIPTION
Add support for use of IAS Production Service (as.sgx.trustedservices.intel.com) when either configured in the settings file or using cmdline option on Linux based systems.

Also updated README to reflect the latest OpenSSL version 1.1.0i