### PR TITLE
Added support to properly close the Remote Attestation Session 

### DIFF
--- a/Enclave/Enclave.cpp
+++ b/Enclave/Enclave.cpp
@@ -151,3 +151,10 @@ sgx_status_t enclave_ra_init_def(int b_pse, sgx_ra_context_t *ctx,
 	return enclave_ra_init(def_service_public_key, b_pse, ctx, pse_status);
 }
 
+
+sgx_status_t enclave_ra_close(sgx_ra_context_t ctx)
+{
+        sgx_status_t ret;
+        ret = sgx_ra_close(ctx);
+        return ret;
+}

--- a/Enclave/Enclave.edl
+++ b/Enclave/Enclave.edl
@@ -43,6 +43,8 @@ enclave {
 
 		public sgx_status_t enclave_ra_init_def(int b_pse,
 			[out] sgx_ra_context_t *ctx, [out] sgx_status_t *pse_status);
+
+                public sgx_status_t enclave_ra_close(sgx_ra_context_t ctx);
 	};
 
 	untrusted {

--- a/client.cpp
+++ b/client.cpp
@@ -493,6 +493,7 @@ int do_attestation (sgx_enclave_id_t eid, config_t *config)
 
 	status = sgx_get_extended_epid_group_id(&msg0_extended_epid_group_id);
 	if ( status != SGX_SUCCESS ) {
+                enclave_ra_close(eid, &sgxrv, ra_ctx); 
 		fprintf(stderr, "sgx_get_extended_epid_group_id: %08x\n", status);
 		return 1;
 	}
@@ -515,6 +516,7 @@ int do_attestation (sgx_enclave_id_t eid, config_t *config)
 
 	status= sgx_ra_get_msg1(ra_ctx, eid, sgx_ra_get_ga, &msg1);
 	if ( status != SGX_SUCCESS ) {
+                enclave_ra_close(eid, &sgxrv, ra_ctx);
 		fprintf(stderr, "sgx_ra_get_msg1: %08x\n", status);
 		fprintf(fplog, "sgx_ra_get_msg1: %08x\n", status);
 		return 1;
@@ -575,9 +577,11 @@ int do_attestation (sgx_enclave_id_t eid, config_t *config)
 
 	rv= msgio->read((void **) &msg2, NULL);
 	if ( rv == 0 ) {
+                enclave_ra_close(eid, &sgxrv, ra_ctx);
 		fprintf(stderr, "protocol error reading msg2\n");
 		exit(1);
 	} else if ( rv == -1 ) {
+                enclave_ra_close(eid, &sgxrv, ra_ctx);
 		fprintf(stderr, "system error occurred while reading msg2\n");
 		exit(1);
 	}
@@ -650,6 +654,7 @@ int do_attestation (sgx_enclave_id_t eid, config_t *config)
 	}
 
 	if ( status != SGX_SUCCESS ) {
+                enclave_ra_close(eid, &sgxrv, ra_ctx);
 		fprintf(stderr, "sgx_ra_proc_msg2: %08x\n", status);
 		fprintf(fplog, "sgx_ra_proc_msg2: %08x\n", status);
 
@@ -781,6 +786,8 @@ int do_attestation (sgx_enclave_id_t eid, config_t *config)
 		free (msg4);
 		msg4 = NULL;
 	}
+
+        enclave_ra_close(eid, &sgxrv, ra_ctx);
    
 	return 0;
 }

--- a/iasrequest.h
+++ b/iasrequest.h
@@ -35,8 +35,10 @@ using namespace std;
 #define IAS_F_DEFAULT		IAS_F_VERIFY_PEER
 #define IAS_F_VERIFY_PEER	0x1
 
-/* v1 API has been EOL'd */
+/* IAS API v1 has been EOL'd */
+/* IAS API v2 has been deprecated as of Aug-17-2018 */
 #define IAS_MIN_VERSION	2
+/* IAS API v3 is the latest supported API */ 
 #define IAS_MAX_VERSION	3
 
 #define IAS_PROXY_NONE	0

--- a/settings.h
+++ b/settings.h
@@ -8,7 +8,7 @@
  *
  * This can be overriden by the -r option to sp.
  */
-#define IAS_API_DEF_VERSION     2
+#define IAS_API_DEF_VERSION    3 
 
 /*----------------------------------------------------------------------
  * CA Certificate Bundles


### PR DESCRIPTION
Make sure we call sgx_ra_close() to close out the Remote Attestation Session after it has been initiated.