### PR TITLE
Configure fix for openssl include directory.

### DIFF
--- a/configure
+++ b/configure
@@ -4764,6 +4764,7 @@ if test "$openssl" != ""; then :
 	old_LIBS="$LIBS"
 	old_CPPFLAGS="$CPPFLAGS"
 	LDFLAGS="$LDFLAGS -L${openssl}/lib"
+	CPPFLAGS="$CPPFLAGS -I${openssl}/include"
 
 fi
 


### PR DESCRIPTION
Fixed configure to use given openssl include folder, as configure will fail if libssl-dev package has been removed prior.