### PR TITLE
Fix possible buffer overflow when parsing msg4

### DIFF
--- a/sp.cpp
+++ b/sp.cpp
@@ -1357,7 +1357,7 @@ int get_attestation_report(IAS_Connection *ias, int version,
 		pibBuff.erase(pibBuff.begin(), pibBuff.begin() + (4*2)); 
 
 		int ret = from_hexstring ((unsigned char *)&msg4->platformInfoBlob, 
-			pibBuff.c_str(), pibBuff.length());
+			pibBuff.c_str(), pibBuff.length()/2);
 	} else {
 		if ( verbose ) eprintf("A Platform Info Blob (PIB) was NOT provided by the IAS\n");
 	}


### PR DESCRIPTION
The argument 'len' of from_hexstring() should be the number of bytes, instead of the string length.